### PR TITLE
(feature): Build Script

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -17,18 +17,15 @@ You can now use the provided build script to automatically create an `.iso` from
 
 ## On Debian/Ubuntu or WSL with Ubuntu:
 
-1. Make sure you have the following dependencies installed: `zip`, `unzip`, and `genisoimage`.
-   The build script will attempt to install them automatically if they are missing.
-
-2. Open a terminal in the template directory and run:
+1. Open a terminal in the template directory and run:
 
 ```bash
 bash build.sh
 ```
 
-3. The script will build out the ISO, its pretty self explanatory
+2. The script will build out the ISO, its pretty self explanatory
 
-4. Once the ISO is created, you can open it in PCSX2 like any other PS2 game.
+3. Once the ISO is created, you can open it in PCSX2 like any other PS2 game.
 
 ## On Windows (without native Linux tools):
 

--- a/README.MD
+++ b/README.MD
@@ -5,6 +5,8 @@ This is made possible by the AthenaEnv engine.
 
 # How to Run?
 
+See the [How to build the ISO](#how-to-make-an-iso) section for instructions, or you can read below.
+
 Assuming that you have a working PCSX2 emulator on your machine and that you have enabled the
 checkbox "Enable host filesystem" under Settings > Emulation.
 

--- a/README.MD
+++ b/README.MD
@@ -13,26 +13,44 @@ In PCSX2, you can achieve this under System > Start File... by selecting the `at
 
 # How to Make an .iso?
 
-You might want to build a single .iso file you can distribute your game as.
-To achieve this, create a zip of all the files present in this template.
-This includes your source code, `athena.elf`, `athena.ini`, `ATHA_000.01` and `SYSTEM.CNF`.
-Exclude this readme.
+You can now use the provided build script to automatically create an `.iso` from the template files.
 
-Make sure to create the zip archive by selecting each file and folder one by one rather than zipping the outer folder
-containing everything. It might still work, but I only had success with the former method.
+## On Debian/Ubuntu or WSL with Ubuntu:
 
-Once the zip is created, you can convert it into an `.iso` with this website https://mconverter.eu/.
-If you know of other alternatives that successfully builds an `.iso` that runs, feel free to make a pull request.
+1. Make sure you have the following dependencies installed: `zip`, `unzip`, and `genisoimage`.
+   The build script will attempt to install them automatically if they are missing.
 
-Once the `.iso` is created, you can open it up in the emulator like you would any other PS2 game.
+2. Open a terminal in the template directory and run:
+
+```bash
+bash build.sh
+```
+
+3. The script will build out the ISO, its pretty self explanatory
+
+4. Once the ISO is created, you can open it in PCSX2 like any other PS2 game.
+
+## On Windows (without native Linux tools):
+
+1. Install [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) and set up a Debian or Ubuntu distribution.
+
+2. Open a WSL terminal in the directory containing this template.
+
+3. Run the build script:
+
+```bash
+bash build.sh
+```
+
+4. After the script finishes, the ISO will be available at `build/output.iso`. You can then use it in PCSX2.
 
 # For More Resources
 
-- [PS2 Sonic Infinite Runner Source Code](https://github.com/DevWill-hub/Sonic-Infinite-Runner-PS2)
-- [The Athena Env repo, documentation included in README](https://github.com/DanielSant0s/AthenaEnv)
+* [PS2 Sonic Infinite Runner Source Code](https://github.com/DevWill-hub/Sonic-Infinite-Runner-PS2)
+* [The Athena Env repo, documentation included in README](https://github.com/DanielSant0s/AthenaEnv)
 
 # Important
 
-The version available in the repository is a stable version called AthenaEnv V4. The documentation/README has been updated to: https://github.com/DanielSant0s/AthenaEnv/blob/v4/README.md
+The version available in the repository is a stable version called AthenaEnv V4. The documentation/README has been updated to: [https://github.com/DanielSant0s/AthenaEnv/blob/v4/README.md](https://github.com/DanielSant0s/AthenaEnv/blob/v4/README.md)
 
 You can still use the version available in the AthenaEnv GitHub Releases section, the most stable version, but remember to use the documentation/README already available from the beginning.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+TMPDIR="$(mktemp -d)"
+ZIPFILE="$TMPDIR/all_files.zip"
+EXTRACTDIR="$TMPDIR/extract"
+OUTPUTDIR="build"
+ISOFILE="$OUTPUTDIR/output.iso"
+
+REQUIRED_CMDS=(zip unzip genisoimage)
+
+missing=()
+for c in "${REQUIRED_CMDS[@]}"; do
+  if ! command -v "$c" >/dev/null 2>&1; then
+    missing+=("$c")
+  fi
+done
+
+if [ ${#missing[@]} -ne 0 ]; then
+  echo "Missing required commands: ${missing[*]}"
+  echo "Installing missing packages via apt"
+  sudo apt update -y
+  sudo apt install -y "${missing[@]}"
+fi
+
+if [ -d "$OUTPUTDIR" ]; then
+  echo "Removing existing '$OUTPUTDIR' directory"
+  rm -rf "$OUTPUTDIR"
+fi
+
+mkdir -p "$OUTPUTDIR"
+mkdir -p "$EXTRACTDIR"
+
+echo "[1/3] Creating ZIP of current directory"
+zip -r "$ZIPFILE" . -x "$SCRIPT_NAME" "$OUTPUTDIR/*" >/dev/null
+
+echo "[2/3] Extracting ZIP to temporary folder"
+unzip -q "$ZIPFILE" -d "$EXTRACTDIR"
+
+echo "[3/3] Creating ISO at '$ISOFILE'"
+genisoimage -o "$ISOFILE" -V "PROJECT" -J -r "$EXTRACTDIR"
+
+rm -rf "$TMPDIR"
+
+echo "Done! ISO created at -> '$ISOFILE'."


### PR DESCRIPTION
Just added a build script to make things easier so you don’t have to use that website to convert it. It works on Ubuntu or Debian and if you are on Windows you can use WSL. I also updated the README.md with instructions on how to run the script and a link for installing WSL on Windows. FYI the script will automatically check for the required dependencies and install them if they are missing.